### PR TITLE
Removed deprecated annotation

### DIFF
--- a/src/FormHandlerInterface.php
+++ b/src/FormHandlerInterface.php
@@ -7,7 +7,6 @@ use Symfony\Component\Form\FormTypeInterface;
 /**
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
  * @author Yannick de Lange <ydelange@hostnet.nl>
- * @deprecated use NamedFormHandlerInterface or AbstractFormHandler
  */
 interface FormHandlerInterface
 {


### PR DESCRIPTION
Removed deprecated annotation, since else we cannot nicely typehint the handlers