### PR TITLE
Made named form use create when name is null

### DIFF
--- a/src/AbstractFormHandler.php
+++ b/src/AbstractFormHandler.php
@@ -18,7 +18,7 @@ abstract class AbstractFormHandler implements NamedFormHandlerInterface
      */
     public function getName()
     {
-        return $this->getType();
+        return null;
     }
 
     /**

--- a/src/Simple/SimpleFormProvider.php
+++ b/src/Simple/SimpleFormProvider.php
@@ -38,15 +38,19 @@ class SimpleFormProvider implements FormProviderInterface
         if (null !== $form) {
             $handler->setForm($form);
         } elseif (null === ($form = $handler->getForm())) {
-            if ($handler instanceof NamedFormHandlerInterface) {
+            if ($handler instanceof NamedFormHandlerInterface && null !== ($name = $handler->getName())) {
                 $form = $this->form_factory->createNamed(
-                    $handler->getName(),
+                    $name,
                     $handler->getType(),
                     $handler->getData(),
                     $handler->getOptions()
                 );
             } else {
-                $form = $this->form_factory->create($handler->getType(), $handler->getData(), $handler->getOptions());
+                $form = $this->form_factory->create(
+                    $handler->getType(),
+                    $handler->getData(),
+                    $handler->getOptions()
+                );
             }
 
             if (!$form instanceof FormInterface) {

--- a/test/AbstractFormHandlerTest.php
+++ b/test/AbstractFormHandlerTest.php
@@ -23,7 +23,7 @@ class AbstractFormHandlerTest extends \PHPUnit_Framework_TestCase
 
         $form = $this->getMock('Symfony\Component\Form\FormInterface');
 
-        $this->assertEquals('foobar', $this->handler->getName());
+        $this->assertEquals(null, $this->handler->getName());
         $this->assertEquals([], $this->handler->getOptions());
         $this->assertSame($form, $this->handler->setForm($form)->getForm());
     }

--- a/test/Simple/SimpleFormProviderTest.php
+++ b/test/Simple/SimpleFormProviderTest.php
@@ -127,10 +127,41 @@ class SimpleFormProviderTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getOptions')
             ->willReturn([]);
+        $named_handler
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('foobar');
 
         $this->factory
             ->expects($this->once())
             ->method('createNamed')
+            ->willReturn($this->form);
+
+        $named_handler
+            ->expects($this->once())
+            ->method('setForm')
+            ->with($this->form);
+
+        $provider = new SimpleFormProvider($this->factory);
+        $provider->handle(new Request(), $named_handler);
+    }
+
+    public function testNamedFormWithNoName()
+    {
+        $named_handler = $this->getMock('Hostnet\Component\Form\NamedFormHandlerInterface');
+
+        $named_handler
+            ->expects($this->once())
+            ->method('getOptions')
+            ->willReturn([]);
+        $named_handler
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn(null);
+
+        $this->factory
+            ->expects($this->once())
+            ->method('create')
             ->willReturn($this->form);
 
         $named_handler


### PR DESCRIPTION
This will no longer make a named form when no name was supplied. Should be backward compatible.

This makes it possible to use class names are type values instead of the service aliases we used before.