### PR TITLE
Made form handler stateless

### DIFF
--- a/src/AbstractFormHandler.php
+++ b/src/AbstractFormHandler.php
@@ -10,6 +10,7 @@ abstract class AbstractFormHandler implements NamedFormHandlerInterface
 {
     /**
      * @var FormInterface
+     * @deprecated since 1.4 and to be removed in 2.0.
      */
     private $form;
 

--- a/src/FormFailureHandlerInterface.php
+++ b/src/FormFailureHandlerInterface.php
@@ -1,6 +1,7 @@
 <?php
 namespace Hostnet\Component\Form;
 
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -13,5 +14,5 @@ interface FormFailureHandlerInterface
      * @param Request $request
      * @return mixed
      */
-    public function onFailure(Request $request);
+    public function onFailure(Request $request, FormInterface $form);
 }

--- a/src/FormHandlerInterface.php
+++ b/src/FormHandlerInterface.php
@@ -17,6 +17,7 @@ interface FormHandlerInterface
 
     /**
      * @return mixed
+     * @deprecated deprecated since 1.4 and to be removed in 2.0. Pass data as a parameter into the handle function instead
      */
     public function getData();
 
@@ -27,11 +28,13 @@ interface FormHandlerInterface
 
     /**
      * @return FormInterface
+     * @deprecated deprecated since 1.4 and to be removed in 2.0. Pass form as a parameter into the handle function instead
      */
     public function getForm();
 
     /**
      * @param FormInterface $form
+     * @deprecated deprecated since 1.4 and to be removed in 2.0. Pass form as a parameter into the handle function instead
      */
     public function setForm(FormInterface $form);
 }

--- a/src/FormProviderInterface.php
+++ b/src/FormProviderInterface.php
@@ -14,6 +14,7 @@ interface FormProviderInterface
      * @param Request              $request
      * @param FormHandlerInterface $handler
      * @param FormInterface        $form
+     * @param mixed                $data initial data for a form if needed
      */
-    public function handle(Request $request, FormHandlerInterface $handler, FormInterface $form = null);
+    public function handle(Request $request, FormHandlerInterface $handler, FormInterface $form = null, $data);
 }

--- a/src/FormSuccessHandlerInterface.php
+++ b/src/FormSuccessHandlerInterface.php
@@ -1,6 +1,7 @@
 <?php
 namespace Hostnet\Component\Form;
 
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -11,7 +12,8 @@ interface FormSuccessHandlerInterface
 {
     /**
      * @param Request $request
+     * @param FormInterface $form
      * @return mixed
      */
-    public function onSuccess(Request $request);
+    public function onSuccess(Request $request, FormInterface $form);
 }

--- a/src/Simple/SimpleFormProvider.php
+++ b/src/Simple/SimpleFormProvider.php
@@ -33,7 +33,7 @@ class SimpleFormProvider implements FormProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(Request $request, FormHandlerInterface $handler, FormInterface $form = null)
+    public function handle(Request $request, FormHandlerInterface $handler, FormInterface $form = null, $data = null)
     {
         if (null !== $form) {
             $handler->setForm($form);
@@ -42,13 +42,13 @@ class SimpleFormProvider implements FormProviderInterface
                 $form = $this->form_factory->createNamed(
                     $name,
                     $handler->getType(),
-                    $handler->getData(),
+                    $data ?: $handler->getData(),
                     $handler->getOptions()
                 );
             } else {
                 $form = $this->form_factory->create(
                     $handler->getType(),
-                    $handler->getData(),
+                    $data ?: $handler->getData(),
                     $handler->getOptions()
                 );
             }
@@ -69,10 +69,10 @@ class SimpleFormProvider implements FormProviderInterface
 
         if ($form->isValid()) {
             if ($handler instanceof FormSuccessHandlerInterface) {
-                return $handler->onSuccess($request);
+                return $handler->onSuccess($request, $form);
             }
         } elseif ($handler instanceof FormFailureHandlerInterface) {
-            return $handler->onFailure($request);
+            return $handler->onFailure($request, $form);
         }
     }
 }


### PR DESCRIPTION
Created stateless form handlers

@stof, is this what you had in mind in a comment inside http://wouterj.nl/2016/08/trimming-your-controllers-using-form-handlers/

I know I made a BC by extending `Form(Failure|Success)HandlerInterface` any suggestions on new interface name?

What I don't particularity like is that with deprecation of `getForm` you don't have access to form automatically created by the `SimpleFormProvider`, which is really nice feature. This means that you cannot re-render it inside a controller in case of failure.  
Unless we mark the $from parameter as a reference, but this will create yet another BC break?