### PR TITLE
Added new stateless form handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/http-foundation": "^2.7||^3.0"
     },
     "require-dev": {
-        "hostnet/phpcs-tool":     "^4.0.8",
+        "hostnet/phpcs-tool":     "^4.1",
         "phpunit/phpunit":        "^5.4",
         "symfony/debug":          "^2.7||^3.0",
         "symfony/phpunit-bridge": "^2.7||^3.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset name="form-handler-component">
+    <rule ref="Hostnet" />
+</ruleset>

--- a/src/FormHandler/ActionSubscriberInterface.php
+++ b/src/FormHandler/ActionSubscriberInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+/**
+ * Implementation of this interface allows for easy registration of Handler
+ * Actions.
+ *
+ * @see HandlerActions
+ */
+interface ActionSubscriberInterface
+{
+    /**
+     * Returns an array of action names this subscriber wants to listen to.
+     *
+     * The returned array should contain a flat structure where the key is the
+     * action and the value the method name that should be called.
+     *
+     * For instance:
+     *     return [HandlerActions::SUCCESS => 'onSuccess'];
+     *
+     * @return array The actions names to listen to
+     */
+    public function getSubscribedActions();
+}

--- a/src/FormHandler/Exception/InvalidHandlerTypeException.php
+++ b/src/FormHandler/Exception/InvalidHandlerTypeException.php
@@ -1,0 +1,17 @@
+<?php
+namespace Hostnet\Component\FormHandler\Exception;
+
+/**
+ * Exception thrown when non-existing handler was requests.
+ */
+class InvalidHandlerTypeException extends \InvalidArgumentException
+{
+    /**
+     * @param string          $name
+     * @param \Exception|null $previous
+     */
+    public function __construct($name, \Exception $previous = null)
+    {
+        parent::__construct(sprintf('No handler found for class "%s".', $name), 0, $previous);
+    }
+}

--- a/src/FormHandler/Exception/UnknownSubscribedActionException.php
+++ b/src/FormHandler/Exception/UnknownSubscribedActionException.php
@@ -1,0 +1,22 @@
+<?php
+namespace Hostnet\Component\FormHandler\Exception;
+
+/**
+ * Exception thrown when trying to subscribe on an unknown action.
+ */
+class UnknownSubscribedActionException extends \LogicException
+{
+    /**
+     * @param string          $class
+     * @param array|string[]  $extra
+     * @param \Exception|null $previous
+     */
+    public function __construct($class, array $extra, \Exception $previous = null)
+    {
+        parent::__construct(sprintf(
+            'Unknown subscribed action(s) "%s" given by "%s".',
+            implode('", "', $extra),
+            $class
+        ), 0, $previous);
+    }
+}

--- a/src/FormHandler/FormSubmitProcessor.php
+++ b/src/FormHandler/FormSubmitProcessor.php
@@ -1,0 +1,72 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Processor when handling the submit of a form.
+ *
+ * @internal
+ */
+final class FormSubmitProcessor
+{
+    /**
+     * @var FormInterface
+     */
+    private $form;
+
+    /**
+     * @var callable|null
+     */
+    private $on_success;
+
+    /**
+     * @var callable|null
+     */
+    private $on_failure;
+
+    /**
+     * @param FormInterface $form
+     * @param callable|null $on_success
+     * @param callable|null $on_failure
+     */
+    public function __construct(
+        FormInterface $form,
+        callable $on_success = null,
+        callable $on_failure = null
+    ) {
+        $this->on_success = $on_success;
+        $this->on_failure = $on_failure;
+        $this->form       = $form;
+    }
+
+    /**
+     * @return FormInterface
+     */
+    public function getForm()
+    {
+        return $this->form;
+    }
+
+    /**
+     * @param Request $request
+     * @return mixed
+     */
+    public function process(Request $request)
+    {
+        $this->form->handleRequest($request);
+
+        if (!$this->form->isSubmitted()) {
+            return null;
+        }
+
+        if ($this->form->isValid()) {
+            if (is_callable($this->on_success)) {
+                return call_user_func($this->on_success, $this->form->getData(), $this->form, $request);
+            }
+        } elseif (is_callable($this->on_failure)) {
+            return call_user_func($this->on_failure, $this->form->getData(), $this->form, $request);
+        }
+    }
+}

--- a/src/FormHandler/Handler.php
+++ b/src/FormHandler/Handler.php
@@ -1,0 +1,102 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Handler wraps around a form and provides a way to handle the form validation
+ * results.
+ *
+ * It will contain the form it belongs to and two callables for processing a
+ * valid and an invalid form validation result.
+ *
+ * @internal Will be removed when upgrading to PHP 7.0 with anonymous class.
+ */
+final class Handler implements HandlerInterface
+{
+    /**
+     * @var FormSubmitProcessor
+     */
+    private $submit_processor;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $form_factory;
+
+    /**
+     * @var HandlerTypeInterface
+     */
+    private $handler_type;
+
+    /**
+     * @param FormFactoryInterface $form_factory
+     * @param HandlerTypeInterface $handler_type
+     */
+    public function __construct(
+        FormFactoryInterface $form_factory,
+        HandlerTypeInterface $handler_type
+    ) {
+        $this->form_factory = $form_factory;
+        $this->handler_type = $handler_type;
+    }
+
+    /**
+     * Implemented to preserve backwards compatibility between the old handlers
+     * and the new.
+     *
+     * @param string $name
+     * @param array  $arguments
+     * @return mixed
+     * @throws \BadMethodCallException when called on something else than a HandlerTypeAdapter
+     */
+    public function __call($name, $arguments)
+    {
+        if (!$this->handler_type instanceof HandlerTypeAdapter) {
+            throw new \BadMethodCallException(sprintf(
+                'Attempted to call an undefined method named "%s" of class "%s".',
+                $name,
+                get_class($this)
+            ));
+        }
+
+        @trigger_error(sprintf(
+            'Delegating call "%s::%s()", please use your data object to transfer data from your controller to the ' .
+            'handler.',
+            $this->handler_type->getHandlerClass(),
+            $name
+        ), E_USER_DEPRECATED);
+
+        return $this->handler_type->delegateCall($name, $arguments);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getForm()
+    {
+        if (null === $this->submit_processor) {
+            throw new \LogicException('Cannot retrieve form when it has not been handled.');
+        }
+
+        return $this->submit_processor->getForm();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Request $request, $data = null)
+    {
+        if ($this->handler_type instanceof HandlerTypeAdapter) {
+            $data = $this->handler_type->syncData($data);
+        }
+
+        $builder = new HandlerBuilder();
+        $this->handler_type->configure($builder);
+
+        $this->submit_processor = $builder->build($this->form_factory, $data);
+
+        return $this->submit_processor->process($request);
+    }
+}

--- a/src/FormHandler/HandlerActions.php
+++ b/src/FormHandler/HandlerActions.php
@@ -1,0 +1,30 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+/**
+ * Actions the Handler supports. These can be registered using the
+ * ActionSubscriberInterface.
+ *
+ * @see ActionSubscriberInterface
+ */
+final class HandlerActions
+{
+    /**
+     * The success action is triggered when the form is submitted and is
+     * validated correctly.
+     */
+    const SUCCESS = 'success';
+
+    /**
+     * The failure case is triggered when the form is submitted and is not
+     * validated correctly.
+     */
+    const FAILURE = 'failure';
+
+    /**
+     * @codeCoverageIgnore private by design because this is an ENUM class
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/FormHandler/HandlerBuilder.php
+++ b/src/FormHandler/HandlerBuilder.php
@@ -1,0 +1,107 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Exception\UnknownSubscribedActionException;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * Allows for configuring and creating HandlerInterface instances.
+ */
+final class HandlerBuilder implements HandlerConfigInterface
+{
+    private $type = FormType::class;
+    private $name;
+    private $options = [];
+    private $on_success;
+    private $on_failure;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onSuccess(callable $callback)
+    {
+        $this->on_success = $callback;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onFailure(callable $callback)
+    {
+        $this->on_failure = $callback;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerActionSubscriber(ActionSubscriberInterface $action_subscriber)
+    {
+        $subscribed_actions = $action_subscriber->getSubscribedActions();
+        $diff               = array_diff(
+            array_keys($subscribed_actions),
+            [HandlerActions::SUCCESS, HandlerActions::FAILURE]
+        );
+
+        if (count($diff) > 0) {
+            throw new UnknownSubscribedActionException(get_class($action_subscriber), $diff);
+        }
+
+        $actions = array_merge(
+            [HandlerActions::SUCCESS => null, HandlerActions::FAILURE => null],
+            $subscribed_actions
+        );
+
+        $this->on_success = $actions[HandlerActions::SUCCESS]
+            ? [$action_subscriber, $actions[HandlerActions::SUCCESS]]
+            : null;
+
+        $this->on_failure = $actions[HandlerActions::FAILURE]
+            ? [$action_subscriber, $actions[HandlerActions::FAILURE]]
+            : null;
+    }
+
+    /**
+     * Create a handler which is able to process the request.
+     *
+     * @param FormFactoryInterface $form_factory
+     * @param mixed                $data
+     * @return FormSubmitProcessor
+     */
+    public function build(FormFactoryInterface $form_factory, $data = null)
+    {
+        $options = is_callable($this->options) ? call_user_func($this->options, $data) : $this->options;
+
+        if (null !== $this->name) {
+            $form = $form_factory->createNamed($this->name, $this->type, $data, $options);
+        } else {
+            $form = $form_factory->create($this->type, $data, $options);
+        }
+
+        return new FormSubmitProcessor($form, $this->on_success, $this->on_failure);
+    }
+}

--- a/src/FormHandler/HandlerConfigInterface.php
+++ b/src/FormHandler/HandlerConfigInterface.php
@@ -1,0 +1,65 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Exception\UnknownSubscribedActionException;
+
+/**
+ * Implementations of the config allow for configuring the handler information.
+ * This information contains items like the type, options and onSuccess
+ * callables.
+ */
+interface HandlerConfigInterface
+{
+    /**
+     * Type to use for creating the form. This is usually a class name of a
+     * form type.
+     *
+     * @param string $type
+     */
+    public function setType($type);
+
+    /**
+     * Name of the form, this is used to create a named form.
+     *
+     * @param string $name
+     */
+    public function setName($name);
+
+    /**
+     * Options to use when creating the form. This can be an array or a
+     * callable. The callable will receive one parameter, the bind data
+     * instance.
+     *
+     * Note: this method is called before form submission, so the data contains
+     * the bind data from your controller. NOT the submitted data.
+     *
+     * @param array|callable $options
+     */
+    public function setOptions($options);
+
+    /**
+     * Register the on success action.
+     *
+     * @param callable $callback
+     */
+    public function onSuccess(callable $callback);
+
+    /**
+     * Register the on failure action.
+     *
+     * @param callable $callback
+     */
+    public function onFailure(callable $callback);
+
+    /**
+     * Register an action subscriber. If an unknown action is given, a
+     * UnknownSubscribedActionException is thrown.
+     *
+     * Note: this method will override any success or failure actions that
+     * were previously defined.
+     *
+     * @param ActionSubscriberInterface $action_subscriber
+     * @throws UnknownSubscribedActionException
+     */
+    public function registerActionSubscriber(ActionSubscriberInterface $action_subscriber);
+}

--- a/src/FormHandler/HandlerFactory.php
+++ b/src/FormHandler/HandlerFactory.php
@@ -1,0 +1,38 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * Factory for creating handlers.
+ */
+final class HandlerFactory implements HandlerFactoryInterface
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $form_factory;
+
+    /**
+     * @var HandlerRegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @param FormFactoryInterface     $form_factory
+     * @param HandlerRegistryInterface $registry
+     */
+    public function __construct(FormFactoryInterface $form_factory, HandlerRegistryInterface $registry)
+    {
+        $this->form_factory = $form_factory;
+        $this->registry     = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($class)
+    {
+        return new Handler($this->form_factory, $this->registry->getType($class));
+    }
+}

--- a/src/FormHandler/HandlerFactoryInterface.php
+++ b/src/FormHandler/HandlerFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException;
+
+/**
+ * Implementations for the Handler Factory can create Handlers based on the
+ * given class for the HandlerType.
+ */
+interface HandlerFactoryInterface
+{
+    /**
+     * Create a Handler based on the given class and optionally some data.
+     *
+     * @param string $class
+     * @return HandlerInterface
+     * @throws InvalidHandlerTypeException
+     */
+    public function create($class);
+}

--- a/src/FormHandler/HandlerInterface.php
+++ b/src/FormHandler/HandlerInterface.php
@@ -1,0 +1,28 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Implementations of this class provide the basic handling of a form.
+ */
+interface HandlerInterface
+{
+    /**
+     * Return the form for this handler.
+     *
+     * @return FormInterface
+     * @throws \LogicException thrown when trying to retrieve a form of a non-handled handler.
+     */
+    public function getForm();
+
+    /**
+     * Handle the form based on the request.
+     *
+     * @param Request $request
+     * @param mixed   $data
+     * @return mixed
+     */
+    public function handle(Request $request, $data = null);
+}

--- a/src/FormHandler/HandlerRegistryInterface.php
+++ b/src/FormHandler/HandlerRegistryInterface.php
@@ -1,0 +1,21 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException;
+
+/**
+ * Implementations of this interface allow for fetching a handler type based on
+ * a class name.
+ */
+interface HandlerRegistryInterface
+{
+    /**
+     * Return the HandlerType for a given class name. If none was found a
+     * InvalidHandlerTypeException is thrown.
+     *
+     * @param string $class
+     * @return HandlerTypeInterface
+     * @throws InvalidHandlerTypeException
+     */
+    public function getType($class);
+}

--- a/src/FormHandler/HandlerTypeAdapter.php
+++ b/src/FormHandler/HandlerTypeAdapter.php
@@ -1,0 +1,113 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\Form\FormFailureHandlerInterface;
+use Hostnet\Component\Form\FormHandlerInterface;
+use Hostnet\Component\Form\FormSuccessHandlerInterface;
+use Hostnet\Component\Form\NamedFormHandlerInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Wrapper class around the old FormHandlerInterface classes. This provides the
+ * BC layer so they can be used with the new handler factory.
+ */
+final class HandlerTypeAdapter implements HandlerTypeInterface
+{
+    /**
+     * @var FormHandlerInterface
+     */
+    private $legacy_handler;
+
+    /**
+     * @param FormHandlerInterface $legacy_handler
+     */
+    public function __construct(FormHandlerInterface $legacy_handler)
+    {
+        $this->legacy_handler = $legacy_handler;
+    }
+
+    /**
+     * Return the original class name.
+     *
+     * @return string
+     */
+    public function getHandlerClass()
+    {
+        return get_class($this->legacy_handler);
+    }
+
+    /**
+     * Make a function call on the old handler and return the results. This is
+     * used to preserve backwards compatibility between the old handlers and the new.
+     *
+     * @return string
+     */
+    public function delegateCall($name, $arguments)
+    {
+        return call_user_func_array([$this->legacy_handler, $name], $arguments);
+    }
+
+    /**
+     * Sync the data from the controller data to the handler data.
+     *
+     * @param mixed $controller_data
+     * @return mixed
+     */
+    public function syncData($controller_data)
+    {
+        if (is_object($controller_data)) {
+            $handler_data = $this->legacy_handler->getData();
+
+            $refl_class = new \ReflectionClass(get_class($handler_data));
+            $filter     = \ReflectionProperty::IS_PUBLIC
+                | \ReflectionProperty::IS_PROTECTED
+                | \ReflectionProperty::IS_PRIVATE;
+
+            foreach ($refl_class->getProperties($filter) as $property) {
+                $property->setAccessible(true);
+                $property->setValue($handler_data, $property->getValue($controller_data));
+                $property->setAccessible(false);
+            }
+        }
+
+        return $this->legacy_handler->getData();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(HandlerConfigInterface $config)
+    {
+        @trigger_error(sprintf(
+            'Using %s is deprecated, use %s instead.',
+            FormHandlerInterface::class,
+            HandlerTypeInterface::class
+        ), E_USER_DEPRECATED);
+
+        if ($this->legacy_handler instanceof NamedFormHandlerInterface
+            && null !== ($name = $this->legacy_handler->getName())
+        ) {
+            $config->setName($name);
+        }
+
+        $config->setType($this->legacy_handler->getType());
+        $config->setOptions($this->legacy_handler->getOptions());
+
+        if ($this->legacy_handler instanceof FormSuccessHandlerInterface) {
+            $config->onSuccess(function ($data, FormInterface $form, Request $request) {
+                $this->legacy_handler->setForm($form);
+
+                return $this->legacy_handler->onSuccess($request);
+            });
+        }
+
+        if ($this->legacy_handler instanceof FormFailureHandlerInterface) {
+            $config->onFailure(function ($data, FormInterface $form, Request $request) {
+                $this->legacy_handler->setForm($form);
+
+                return $this->legacy_handler->onFailure($request);
+            });
+        }
+    }
+}

--- a/src/FormHandler/HandlerTypeInterface.php
+++ b/src/FormHandler/HandlerTypeInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+/**
+ * Implementations for this class allow for configuring of an handler config.
+ */
+interface HandlerTypeInterface
+{
+    /**
+     * Configure the Handler.
+     *
+     * @param HandlerConfigInterface $config
+     */
+    public function configure(HandlerConfigInterface $config);
+}

--- a/test/FormHandler/Exception/InvalidHandlerTypeExceptionTest.php
+++ b/test/FormHandler/Exception/InvalidHandlerTypeExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Hostnet\Component\FormHandler\Exception;
+
+/**
+ * @covers \Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException
+ */
+class InvalidHandlerTypeExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $exception = new InvalidHandlerTypeException('foobar');
+
+        self::assertEquals('No handler found for class "foobar".', $exception->getMessage());
+    }
+}

--- a/test/FormHandler/Exception/UnknownSubscribedActionExceptionTest.php
+++ b/test/FormHandler/Exception/UnknownSubscribedActionExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Hostnet\Component\FormHandler\Exception;
+
+/**
+ * @covers \Hostnet\Component\FormHandler\Exception\UnknownSubscribedActionException
+ */
+class UnknownSubscribedActionExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $exception = new UnknownSubscribedActionException('foobar', ['foo', 'bar']);
+
+        self::assertEquals('Unknown subscribed action(s) "foo", "bar" given by "foobar".', $exception->getMessage());
+    }
+}

--- a/test/FormHandler/Fixtures/ActionSubscriber/FailureSubscriber.php
+++ b/test/FormHandler/Fixtures/ActionSubscriber/FailureSubscriber.php
@@ -1,0 +1,21 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\ActionSubscriber;
+
+use Hostnet\Component\FormHandler\ActionSubscriberInterface;
+use Hostnet\Component\FormHandler\HandlerActions;
+
+class FailureSubscriber implements ActionSubscriberInterface
+{
+    public $success = false;
+    public $failure = false;
+
+    public function getSubscribedActions()
+    {
+        return [HandlerActions::FAILURE => 'onFailure'];
+    }
+
+    public function onFailure()
+    {
+        $this->failure = true;
+    }
+}

--- a/test/FormHandler/Fixtures/ActionSubscriber/HenkSubscriber.php
+++ b/test/FormHandler/Fixtures/ActionSubscriber/HenkSubscriber.php
@@ -1,0 +1,16 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\ActionSubscriber;
+
+use Hostnet\Component\FormHandler\ActionSubscriberInterface;
+
+class HenkSubscriber implements ActionSubscriberInterface
+{
+    public function getSubscribedActions()
+    {
+        return ['henk' => 'onHenk'];
+    }
+
+    public function onHenk()
+    {
+    }
+}

--- a/test/FormHandler/Fixtures/ActionSubscriber/SuccessSubscriber.php
+++ b/test/FormHandler/Fixtures/ActionSubscriber/SuccessSubscriber.php
@@ -1,0 +1,21 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\ActionSubscriber;
+
+use Hostnet\Component\FormHandler\ActionSubscriberInterface;
+use Hostnet\Component\FormHandler\HandlerActions;
+
+class SuccessSubscriber implements ActionSubscriberInterface
+{
+    public $success = false;
+    public $failure = false;
+
+    public function getSubscribedActions()
+    {
+        return [HandlerActions::SUCCESS => 'onSuccess'];
+    }
+
+    public function onSuccess()
+    {
+        $this->success = true;
+    }
+}

--- a/test/FormHandler/Fixtures/ArrayHandlerRegistry.php
+++ b/test/FormHandler/Fixtures/ArrayHandlerRegistry.php
@@ -1,0 +1,29 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures;
+
+use Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException;
+use Hostnet\Component\FormHandler\HandlerRegistryInterface;
+
+final class ArrayHandlerRegistry implements HandlerRegistryInterface
+{
+    private $handlers;
+
+    public function __construct(array $handlers)
+    {
+        $this->handlers = $handlers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType($class)
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler instanceof $class) {
+                return $handler;
+            }
+        }
+
+        throw new InvalidHandlerTypeException($class);
+    }
+}

--- a/test/FormHandler/Fixtures/HandlerType/FullFormHandler.php
+++ b/test/FormHandler/Fixtures/HandlerType/FullFormHandler.php
@@ -1,0 +1,39 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\HandlerType;
+
+use Hostnet\Component\FormHandler\ActionSubscriberInterface;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Hostnet\Component\FormHandler\HandlerActions;
+use Hostnet\Component\FormHandler\HandlerConfigInterface;
+use Hostnet\Component\FormHandler\HandlerTypeInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class FullFormHandler implements HandlerTypeInterface, ActionSubscriberInterface
+{
+    public function configure(HandlerConfigInterface $config)
+    {
+        $config->setType(TestType::class);
+        $config->registerActionSubscriber($this);
+    }
+
+    public function getSubscribedActions()
+    {
+        return [
+            HandlerActions::SUCCESS => 'onSuccess',
+            HandlerActions::FAILURE => 'onFailure',
+        ];
+    }
+
+    public function onSuccess(TestData $data, FormInterface $form, Request $request)
+    {
+        return new RedirectResponse('http://success.nl/');
+    }
+
+    public function onFailure(TestData $data, FormInterface $form, Request $request)
+    {
+        return new RedirectResponse('http://failure.nl/');
+    }
+}

--- a/test/FormHandler/Fixtures/HandlerType/SimpleFormHandler.php
+++ b/test/FormHandler/Fixtures/HandlerType/SimpleFormHandler.php
@@ -1,0 +1,14 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\HandlerType;
+
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Hostnet\Component\FormHandler\HandlerConfigInterface;
+use Hostnet\Component\FormHandler\HandlerTypeInterface;
+
+class SimpleFormHandler implements HandlerTypeInterface
+{
+    public function configure(HandlerConfigInterface $config)
+    {
+        $config->setType(TestType::class);
+    }
+}

--- a/test/FormHandler/Fixtures/Legacy/LegacyFormHandler.php
+++ b/test/FormHandler/Fixtures/Legacy/LegacyFormHandler.php
@@ -1,0 +1,40 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\Legacy;
+
+use Hostnet\Component\Form\AbstractFormHandler;
+use Hostnet\Component\Form\FormFailureHandlerInterface;
+use Hostnet\Component\Form\FormSuccessHandlerInterface;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class LegacyFormHandler extends AbstractFormHandler implements FormSuccessHandlerInterface, FormFailureHandlerInterface
+{
+    private $data;
+
+    public function __construct()
+    {
+        $this->data = new TestData();
+    }
+
+    public function getType()
+    {
+        return TestType::class;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function onSuccess(Request $request)
+    {
+        return new RedirectResponse('http://success.nl/' . $this->data->test);
+    }
+
+    public function onFailure(Request $request)
+    {
+        return new RedirectResponse('http://failure.nl/' . $this->data->test);
+    }
+}

--- a/test/FormHandler/Fixtures/Legacy/LegacyFormVariableOptionsHandler.php
+++ b/test/FormHandler/Fixtures/Legacy/LegacyFormVariableOptionsHandler.php
@@ -1,0 +1,45 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\Legacy;
+
+use Hostnet\Component\Form\AbstractFormHandler;
+use Hostnet\Component\Form\FormFailureHandlerInterface;
+use Hostnet\Component\Form\FormSuccessHandlerInterface;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class LegacyFormVariableOptionsHandler extends AbstractFormHandler implements FormSuccessHandlerInterface, FormFailureHandlerInterface
+{
+    private $data;
+
+    public function __construct()
+    {
+        $this->data = new TestData();
+    }
+
+    public function getOptions()
+    {
+        return ['attr' => ['class' => $this->data->test]];
+    }
+
+    public function getType()
+    {
+        return TestType::class;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function onSuccess(Request $request)
+    {
+        return new RedirectResponse('http://success.nl/' . $this->data->test);
+    }
+
+    public function onFailure(Request $request)
+    {
+        return new RedirectResponse('http://failure.nl/' . $this->data->test);
+    }
+}

--- a/test/FormHandler/Fixtures/Legacy/LegacyNamedFormHandler.php
+++ b/test/FormHandler/Fixtures/Legacy/LegacyNamedFormHandler.php
@@ -1,0 +1,45 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures\Legacy;
+
+use Hostnet\Component\Form\AbstractFormHandler;
+use Hostnet\Component\Form\FormFailureHandlerInterface;
+use Hostnet\Component\Form\FormSuccessHandlerInterface;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class LegacyNamedFormHandler extends AbstractFormHandler implements FormSuccessHandlerInterface, FormFailureHandlerInterface
+{
+    private $data;
+
+    public function __construct()
+    {
+        $this->data = new TestData();
+    }
+
+    public function getType()
+    {
+        return TestType::class;
+    }
+
+    public function getName()
+    {
+        return 'foobar';
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function onSuccess(Request $request)
+    {
+        return new RedirectResponse('http://success.nl/' . $this->data->test);
+    }
+
+    public function onFailure(Request $request)
+    {
+        return new RedirectResponse('http://failure.nl/' . $this->data->test);
+    }
+}

--- a/test/FormHandler/Fixtures/LegacyHandlerRegistry.php
+++ b/test/FormHandler/Fixtures/LegacyHandlerRegistry.php
@@ -1,0 +1,33 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures;
+
+use Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException;
+use Hostnet\Component\FormHandler\HandlerRegistryInterface;
+use Hostnet\Component\FormHandler\HandlerTypeAdapter;
+
+final class LegacyHandlerRegistry implements HandlerRegistryInterface
+{
+    private $handlers;
+
+    public function __construct(array $handlers)
+    {
+        $this->handlers = $handlers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType($class)
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler instanceof $class) {
+                return $handler;
+            }
+            if ($handler instanceof HandlerTypeAdapter && $handler->getHandlerClass() === $class) {
+                return $handler;
+            }
+        }
+
+        throw new InvalidHandlerTypeException($class);
+    }
+}

--- a/test/FormHandler/Fixtures/TestData.php
+++ b/test/FormHandler/Fixtures/TestData.php
@@ -1,0 +1,7 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures;
+
+class TestData
+{
+    public $test;
+}

--- a/test/FormHandler/Fixtures/TestType.php
+++ b/test/FormHandler/Fixtures/TestType.php
@@ -1,0 +1,22 @@
+<?php
+namespace Hostnet\Component\FormHandler\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TestType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('test', TextType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => TestData::class
+        ]);
+    }
+}

--- a/test/FormHandler/FormSubmitProcessorTest.php
+++ b/test/FormHandler/FormSubmitProcessorTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \Hostnet\Component\FormHandler\FormSubmitProcessor
+ */
+class FormSubmitProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    private $form;
+    private $on_success;
+    private $on_failure;
+
+    /**
+     * @var FormSubmitProcessor
+     */
+    private $form_submit_processor;
+
+    protected function setUp()
+    {
+        $this->form       = $this->prophesize(FormInterface::class);
+        $this->on_success = false;
+        $this->on_failure = false;
+
+        $this->form_submit_processor = new FormSubmitProcessor(
+            $this->form->reveal(),
+            function () {
+                $this->on_success = true;
+
+                return 'success';
+            },
+            function () {
+                $this->on_failure = true;
+
+                return 'failure';
+            }
+        );
+    }
+
+    public function testGetForm()
+    {
+        self::assertSame($this->form->reveal(), $this->form_submit_processor->getForm());
+    }
+
+    public function testSubmitNotSubmitted()
+    {
+        $request = Request::create('/', 'POST');
+
+        $this->form->handleRequest($request)->shouldBeCalled();
+        $this->form->isSubmitted()->willReturn(false);
+
+        self::assertNull($this->form_submit_processor->process($request));
+    }
+
+    public function testSubmitValid()
+    {
+        $request = Request::create('/', 'POST');
+
+        $this->form->handleRequest($request)->shouldBeCalled();
+        $this->form->isSubmitted()->willReturn(true);
+        $this->form->isValid()->willReturn(true);
+        $this->form->getData()->willReturn([]);
+
+        self::assertSame('success', $this->form_submit_processor->process($request));
+    }
+
+    public function testSubmitValidNoHandler()
+    {
+        $request               = Request::create('/', 'POST');
+        $form_submit_processor = new FormSubmitProcessor($this->form->reveal());
+
+        $this->form->handleRequest($request)->shouldBeCalled();
+        $this->form->isSubmitted()->willReturn(true);
+        $this->form->isValid()->willReturn(true);
+        $this->form->getData()->willReturn([]);
+
+        self::assertNull($form_submit_processor->process($request));
+    }
+
+    public function testSubmitInvalid()
+    {
+        $request = Request::create('/', 'POST');
+
+        $this->form->handleRequest($request)->shouldBeCalled();
+        $this->form->isSubmitted()->willReturn(true);
+        $this->form->isValid()->willReturn(false);
+        $this->form->getData()->willReturn([]);
+
+        self::assertSame('failure', $this->form_submit_processor->process($request));
+    }
+
+    public function testSubmitInvalidNoHandler()
+    {
+        $request               = Request::create('/', 'POST');
+        $form_submit_processor = new FormSubmitProcessor($this->form->reveal());
+
+        $this->form->handleRequest($request)->shouldBeCalled();
+        $this->form->isSubmitted()->willReturn(true);
+        $this->form->isValid()->willReturn(false);
+        $this->form->getData()->willReturn([]);
+
+        self::assertNull($form_submit_processor->process($request));
+    }
+}

--- a/test/FormHandler/HandlerBackwardsCompatibilityTest.php
+++ b/test/FormHandler/HandlerBackwardsCompatibilityTest.php
@@ -1,0 +1,121 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Fixtures\Legacy\LegacyFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\Legacy\LegacyFormVariableOptionsHandler;
+use Hostnet\Component\FormHandler\Fixtures\LegacyHandlerRegistry;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Prophecy\Argument;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Test\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @group legacy
+ * @coversNothing
+ */
+class HandlerBackwardsCompatibilityTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $request         = Request::create('/', 'GET');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new LegacyHandlerRegistry([new HandlerTypeAdapter(new LegacyFormHandler())])
+        );
+        $data            = new TestData();
+        $data->test      = 'foobar';
+
+        $form = $this->prophesize(FormInterface::class);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        self::assertNull($handler_factory->create(LegacyFormHandler::class)->handle($request, $data));
+    }
+
+    public function testGetOptions()
+    {
+        $request         = Request::create('/', 'GET');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new LegacyHandlerRegistry([new HandlerTypeAdapter(new LegacyFormVariableOptionsHandler())])
+        );
+        $data            = new TestData();
+        $data->test      = 'foobar';
+
+        $form = $this->prophesize(FormInterface::class);
+
+        $form_factory
+            ->create(TestType::class, Argument::type(TestData::class), ['attr' => ['class' => 'foobar']])
+            ->willReturn($form);
+
+        self::assertNull($handler_factory->create(LegacyFormVariableOptionsHandler::class)->handle($request, $data));
+    }
+
+    public function testGetData()
+    {
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new LegacyHandlerRegistry([new HandlerTypeAdapter(new LegacyFormVariableOptionsHandler())])
+        );
+
+        $handler = $handler_factory->create(LegacyFormVariableOptionsHandler::class);
+
+        self::assertInstanceOf(TestData::class, $handler->getData());
+    }
+
+    public function testPostSuccess()
+    {
+        $request         = Request::create('/', 'POST');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new LegacyHandlerRegistry([new HandlerTypeAdapter(new LegacyFormHandler())])
+        );
+        $data            = new TestData();
+        $data->test      = 'foobar';
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn($data);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $resp = $handler_factory->create(LegacyFormHandler::class)->handle($request, $data);
+
+        self::assertInstanceOf(RedirectResponse::class, $resp);
+        self::assertSame('http://success.nl/foobar', $resp->getTargetUrl());
+    }
+
+    public function testPostFailure()
+    {
+        $request         = Request::create('/', 'POST');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new LegacyHandlerRegistry([new HandlerTypeAdapter(new LegacyFormHandler())])
+        );
+        $data            = new TestData();
+        $data->test      = 'foobar';
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(false);
+        $form->getData()->willReturn($data);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $resp = $handler_factory->create(LegacyFormHandler::class)->handle($request, $data);
+
+        self::assertInstanceOf(RedirectResponse::class, $resp);
+        self::assertSame('http://failure.nl/foobar', $resp->getTargetUrl());
+    }
+}

--- a/test/FormHandler/HandlerBuilderTest.php
+++ b/test/FormHandler/HandlerBuilderTest.php
@@ -1,0 +1,206 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Fixtures\ActionSubscriber\FailureSubscriber;
+use Hostnet\Component\FormHandler\Fixtures\ActionSubscriber\HenkSubscriber;
+use Hostnet\Component\FormHandler\Fixtures\ActionSubscriber\SuccessSubscriber;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \Hostnet\Component\FormHandler\HandlerBuilder
+ */
+class HandlerBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetName()
+    {
+        $request      = Request::create('/', 'POST');
+        $form_factory = $this->prophesize(FormFactoryInterface::class);
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn(null);
+
+        $form_factory->createNamed('foobar', TestType::class, null, [])->willReturn($form);
+
+        $builder = new HandlerBuilder();
+        $builder->setType(TestType::class);
+        $builder->setName('foobar');
+
+        $handler = $builder->build($form_factory->reveal());
+        $handler->process($request);
+    }
+
+    public function testSetOptions()
+    {
+        $request      = Request::create('/', 'POST');
+        $form_factory = $this->prophesize(FormFactoryInterface::class);
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn(null);
+
+        $form_factory->create(TestType::class, null, ['foo' => 'bar'])->willReturn($form);
+
+        $builder = new HandlerBuilder();
+        $builder->setType(TestType::class);
+        $builder->setOptions(['foo' => 'bar']);
+
+        $handler = $builder->build($form_factory->reveal());
+        $handler->process($request);
+    }
+
+    public function testSetOptionsCallback()
+    {
+        $request      = Request::create('/', 'POST');
+        $form_factory = $this->prophesize(FormFactoryInterface::class);
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn(null);
+
+        $form_factory->create(TestType::class, null, ['foo' => 'bar'])->willReturn($form);
+
+        $builder = new HandlerBuilder();
+        $builder->setType(TestType::class);
+        $builder->setOptions(function () {
+            return ['foo' => 'bar'];
+        });
+
+        $handler = $builder->build($form_factory->reveal());
+        $handler->process($request);
+    }
+
+    public function testBuildSuccess()
+    {
+        $spy = new SuccessSubscriber();
+
+        $request      = Request::create('/', 'POST');
+        $form_factory = $this->prophesize(FormFactoryInterface::class);
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn(null);
+
+        $form_factory->create(TestType::class, null, [])->willReturn($form);
+
+        $builder = new HandlerBuilder();
+        $builder->registerActionSubscriber($spy);
+        $builder->setType(TestType::class);
+
+        $handler = $builder->build($form_factory->reveal());
+        $handler->process($request);
+
+        self::assertTrue($spy->success);
+        self::assertFalse($spy->failure);
+    }
+
+    public function testBuildFailure()
+    {
+        $spy = new FailureSubscriber();
+
+        $request      = Request::create('/', 'POST');
+        $form_factory = $this->prophesize(FormFactoryInterface::class);
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(false);
+        $form->getData()->willReturn(null);
+
+        $form_factory->create(TestType::class, null, [])->willReturn($form);
+
+        $builder = new HandlerBuilder();
+        $builder->registerActionSubscriber($spy);
+        $builder->setType(TestType::class);
+
+        $handler = $builder->build($form_factory->reveal());
+        $handler->process($request);
+
+        self::assertFalse($spy->success);
+        self::assertTrue($spy->failure);
+    }
+
+    public function testBuildSuccessCallback()
+    {
+        $success = false;
+        $failure = false;
+
+        $request      = Request::create('/', 'POST');
+        $form_factory = $this->prophesize(FormFactoryInterface::class);
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn(null);
+
+        $form_factory->create(TestType::class, null, [])->willReturn($form);
+
+        $builder = new HandlerBuilder();
+        $builder->onSuccess(function () use (&$success) {
+            $success = true;
+        });
+        $builder->onFailure(function () use (&$failure) {
+            $failure = true;
+        });
+        $builder->setType(TestType::class);
+
+        $handler = $builder->build($form_factory->reveal());
+        $handler->process($request);
+
+        self::assertTrue($success);
+        self::assertFalse($failure);
+    }
+
+    public function testBuildFailureCallback()
+    {
+        $success = false;
+        $failure = false;
+
+        $request      = Request::create('/', 'POST');
+        $form_factory = $this->prophesize(FormFactoryInterface::class);
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(false);
+        $form->getData()->willReturn(null);
+
+        $form_factory->create(TestType::class, null, [])->willReturn($form);
+
+        $builder = new HandlerBuilder();
+        $builder->onSuccess(function () use (&$success) {
+            $success = true;
+        });
+        $builder->onFailure(function () use (&$failure) {
+            $failure = true;
+        });
+        $builder->setType(TestType::class);
+
+        $handler = $builder->build($form_factory->reveal());
+        $handler->process($request);
+
+        self::assertFalse($success);
+        self::assertTrue($failure);
+    }
+
+    /**
+     * @expectedException \Hostnet\Component\FormHandler\Exception\UnknownSubscribedActionException
+     */
+    public function testRegisterActionSubscriberWrongAction()
+    {
+        $builder = new HandlerBuilder();
+        $builder->registerActionSubscriber(new HenkSubscriber());
+    }
+}

--- a/test/FormHandler/HandlerFactoryTest.php
+++ b/test/FormHandler/HandlerFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Fixtures\HandlerType\SimpleFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * @covers \Hostnet\Component\FormHandler\HandlerFactory
+ */
+class HandlerFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    private $form_factory;
+    private $registry;
+
+    /**
+     * @var HandlerFactory
+     */
+    private $handler_factory;
+
+    protected function setUp()
+    {
+        $this->form_factory = $this->prophesize(FormFactoryInterface::class);
+        $this->registry     = $this->prophesize(HandlerRegistryInterface::class);
+
+        $this->handler_factory = new HandlerFactory(
+            $this->form_factory->reveal(),
+            $this->registry->reveal()
+        );
+    }
+
+    public function testCreate()
+    {
+        $form = $this->prophesize(FormInterface::class);
+
+        $this->registry->getType('foobar')->willReturn(new SimpleFormHandler());
+
+        $this->form_factory->create(TestType::class, null, [])->willReturn($form);
+
+        $this->handler_factory->create('foobar');
+    }
+}

--- a/test/FormHandler/HandlerTest.php
+++ b/test/FormHandler/HandlerTest.php
@@ -1,0 +1,197 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Fixtures\ArrayHandlerRegistry;
+use Hostnet\Component\FormHandler\Fixtures\HandlerType\FullFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\HandlerType\SimpleFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\Legacy\LegacyFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\LegacyHandlerRegistry;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Prophecy\Argument;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Test\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \Hostnet\Component\FormHandler\Handler
+ */
+class HandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetForm()
+    {
+        $request         = Request::create('/', 'GET');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new ArrayHandlerRegistry([new SimpleFormHandler()])
+        );
+        $data            = new TestData();
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(false);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+        $handler = $handler_factory->create(SimpleFormHandler::class);
+
+        self::assertNull($handler->handle($request, $data));
+        self::assertSame($form->reveal(), $handler->getForm());
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Attempted to call an undefined method named "getData" of class "Hostnet\Component\FormHandler\Handler".
+     */
+    public function testCall()
+    {
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new ArrayHandlerRegistry([new SimpleFormHandler()])
+        );
+
+        $handler_factory->create(SimpleFormHandler::class)->getData();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCallLegacy()
+    {
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new LegacyHandlerRegistry([new HandlerTypeAdapter(new LegacyFormHandler())])
+        );
+
+        self::assertInstanceOf(TestData::class, $handler_factory->create(LegacyFormHandler::class)->getData());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Cannot retrieve form when it has not been handled.
+     */
+    public function testGetFormWhenNotHandled()
+    {
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new ArrayHandlerRegistry([new SimpleFormHandler()])
+        );
+
+        $handler_factory->create(SimpleFormHandler::class)->getForm();
+    }
+
+    public function testSimple()
+    {
+        $request         = Request::create('/', 'POST');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new ArrayHandlerRegistry([new SimpleFormHandler()])
+        );
+        $data            = new TestData();
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn($data);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $handler = $handler_factory->create(SimpleFormHandler::class);
+
+        self::assertNull($handler->handle($request, $data));
+        self::assertSame($form->reveal(), $handler->getForm());
+    }
+
+    public function testPostSuccess()
+    {
+        $request         = Request::create('/', 'POST');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new ArrayHandlerRegistry([new FullFormHandler()])
+        );
+        $data            = new TestData();
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn($data);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $handler = $handler_factory->create(FullFormHandler::class);
+
+        $resp = $handler->handle($request, $data);
+
+        self::assertInstanceOf(RedirectResponse::class, $resp);
+        self::assertSame('http://success.nl/', $resp->getTargetUrl());
+        self::assertSame($form->reveal(), $handler->getForm());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testPostSuccessSyncData()
+    {
+        $request         = Request::create('/', 'POST');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $legacy_handler  = new LegacyFormHandler();
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new LegacyHandlerRegistry([new HandlerTypeAdapter($legacy_handler)])
+        );
+        $data            = new TestData();
+        $data->test      = 'foobar';
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn($data);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $handler = $handler_factory->create(LegacyFormHandler::class);
+
+        $resp = $handler->handle($request, $data);
+
+        self::assertInstanceOf(RedirectResponse::class, $resp);
+        self::assertSame('http://success.nl/foobar', $resp->getTargetUrl());
+        self::assertSame($form->reveal(), $handler->getForm());
+        self::assertSame($data->test, $legacy_handler->getData()->test);
+    }
+
+    public function testPostFailure()
+    {
+        $request         = Request::create('/', 'POST');
+        $form_factory    = $this->prophesize(FormFactoryInterface::class);
+        $handler_factory = new HandlerFactory(
+            $form_factory->reveal(),
+            new ArrayHandlerRegistry([new FullFormHandler()])
+        );
+        $data            = new TestData();
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(false);
+        $form->getData()->willReturn($data);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $handler = $handler_factory->create(FullFormHandler::class);
+
+        $resp = $handler->handle($request, $data);
+
+        self::assertInstanceOf(RedirectResponse::class, $resp);
+        self::assertSame('http://failure.nl/', $resp->getTargetUrl());
+        self::assertSame($form->reveal(), $handler->getForm());
+    }
+}

--- a/test/FormHandler/HandlerTypeAdapterTest.php
+++ b/test/FormHandler/HandlerTypeAdapterTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\FormHandler\Fixtures\Legacy\LegacyFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\Legacy\LegacyNamedFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @group legacy
+ * @covers \Hostnet\Component\FormHandler\HandlerTypeAdapter
+ */
+class HandlerTypeAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRegular()
+    {
+        $adapter = new HandlerTypeAdapter(new LegacyFormHandler());
+        $config  = $this->prophesize(HandlerConfigInterface::class);
+
+        $config->setType(TestType::class)->shouldBeCalled();
+        $config->setName()->shouldNotBeCalled();
+        $config->setOptions([])->shouldBeCalled();
+        $config->onSuccess(Argument::type('callable'))->shouldBeCalled();
+        $config->onFailure(Argument::type('callable'))->shouldBeCalled();
+
+        self::assertEquals(LegacyFormHandler::class, $adapter->getHandlerClass());
+
+        $adapter->configure($config->reveal());
+    }
+
+    public function testNamed()
+    {
+        $adapter = new HandlerTypeAdapter(new LegacyNamedFormHandler());
+        $config  = $this->prophesize(HandlerConfigInterface::class);
+
+        $config->setType(TestType::class)->shouldBeCalled();
+        $config->setName('foobar')->shouldBeCalled();
+        $config->setOptions([])->shouldBeCalled();
+        $config->onSuccess(Argument::type('callable'))->shouldBeCalled();
+        $config->onFailure(Argument::type('callable'))->shouldBeCalled();
+
+        self::assertEquals(LegacyNamedFormHandler::class, $adapter->getHandlerClass());
+
+        $adapter->configure($config->reveal());
+    }
+
+    public function testDelegateCall()
+    {
+        $request        = Request::create('/', 'POST');
+        $legacy_handler = new LegacyNamedFormHandler();
+        $adapter        = new HandlerTypeAdapter($legacy_handler);
+
+        self::assertSame($legacy_handler->getData(), $adapter->delegateCall('getData', []));
+        self::assertSame('http://success.nl/', $adapter->delegateCall('onSuccess', [$request])->getTargetUrl());
+    }
+
+    public function testSyncData()
+    {
+        $controller_data = new TestData();
+        $adapter         = new HandlerTypeAdapter(new LegacyNamedFormHandler());
+
+        $controller_data->test = 'foobar';
+
+        $new_data = $adapter->syncData($controller_data);
+
+        self::assertSame($controller_data->test, $new_data->test);
+    }
+}

--- a/test/FormHandler/LegacyHandlerTest.php
+++ b/test/FormHandler/LegacyHandlerTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Hostnet\Component\FormHandler;
+
+use Hostnet\Component\Form\Simple\SimpleFormProvider;
+use Hostnet\Component\FormHandler\Fixtures\Legacy\LegacyFormHandler;
+use Hostnet\Component\FormHandler\Fixtures\TestData;
+use Hostnet\Component\FormHandler\Fixtures\TestType;
+use Prophecy\Argument;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Test\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @coversNothing
+ */
+class LegacyHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGet()
+    {
+        $request       = Request::create('/', 'GET');
+        $form_factory  = $this->prophesize(FormFactoryInterface::class);
+        $form_provider = new SimpleFormProvider($form_factory->reveal());
+        $handler       = new LegacyFormHandler();
+
+        $form = $this->prophesize(FormInterface::class);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        self::assertNull($form_provider->handle($request, $handler));
+    }
+
+    public function testPostSuccess()
+    {
+        $request       = Request::create('/', 'POST');
+        $form_factory  = $this->prophesize(FormFactoryInterface::class);
+        $form_provider = new SimpleFormProvider($form_factory->reveal());
+        $handler       = new LegacyFormHandler();
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $resp = $form_provider->handle($request, $handler);
+
+        self::assertInstanceOf(RedirectResponse::class, $resp);
+        self::assertSame('http://success.nl/', $resp->getTargetUrl());
+    }
+
+    public function testPostFailure()
+    {
+        $request       = Request::create('/', 'POST');
+        $form_factory  = $this->prophesize(FormFactoryInterface::class);
+        $form_provider = new SimpleFormProvider($form_factory->reveal());
+        $handler       = new LegacyFormHandler();
+
+        $form = $this->prophesize(FormInterface::class);
+        $form->handleRequest($request)->shouldBeCalled();
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(false);
+
+        $form_factory->create(TestType::class, Argument::type(TestData::class), [])->willReturn($form);
+
+        $resp = $form_provider->handle($request, $handler);
+
+        self::assertInstanceOf(RedirectResponse::class, $resp);
+        self::assertSame('http://failure.nl/', $resp->getTargetUrl());
+    }
+}


### PR DESCRIPTION
based on the feedback and discussions in https://github.com/yannickl88/form-handler-component/pull/1

The new definitions would be:
```php
<?php

// use ...

class Handler implements HandlerTypeInterface, ActionSubscriberInterface
{
    public function configure(HandlerConfigInterface $config)
    {
        $config->setType(IntegerType::class);
        $config->setName('foobar');
        $config->setOptions(['foo' => 42]);

        $config->registerActionSubscriber($this);
    }

    public function getSubscribedActions()
    {
        return [HandlerActions::SUCCESS => 'onSuccess'];
    }

    public function onSuccess($data, FormInterface $form, Request $request)
    {
        // Do something
    }
}
```

or using a callback for the `onSuccess`

```php
<?php

// use ...

class Handler implements HandlerTypeInterface
{
    public function configure(HandlerConfigInterface $config)
    {
        $config->setType(IntegerType::class);
        $config->setName('foobar');
        $config->setOptions(['foo' => 42]);

        $config->onSuccess(function ($data, FormInterface $form, Request $request) {
            // Do something
        });
    }
}
```

Usage of the handler will be:

```php
<?php

// use ...

class SomeController
{
    private $handler_factory;
    
    public function __construct(HandlerFactoryInterface $handler_factory)
    {
        $this->handler_factory = $handler_factory;
    }
    
    /**
     * @Route(...)
     * @Template(...)
     */
    public function someAction(Request $request)
    {
        $handler = $this->handler_factory->create(MyHandler::class);
        $data = new MyData();

        if (($response = $handler->handle($request, $data)) instanceof RedirectResponse) {
            return $response;
        }

        return ['form' => $handler->getForm()->createView()];
    }
}
```

There is also a BC layer present, which makes it possible to use the old `FormHandlerInterface` classes with the new `HandlerFactory`. This way migration is more smooth.