### PR TITLE
Revert Throw InvalidHandlerTypeException when Handler type is invalid

### DIFF
--- a/src/FormHandler/HandlerBuilder.php
+++ b/src/FormHandler/HandlerBuilder.php
@@ -1,11 +1,9 @@
 <?php
 namespace Hostnet\Component\FormHandler;
 
-use Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException;
 use Hostnet\Component\FormHandler\Exception\UnknownSubscribedActionException;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * Allows for configuring and creating HandlerInterface instances.
@@ -101,20 +99,10 @@ final class HandlerBuilder implements HandlerConfigInterface
      *
      * @param FormFactoryInterface $form_factory
      * @param mixed                $data
-     * @throws InvalidHandlerTypeException
      * @return FormSubmitProcessor
      */
     public function build(FormFactoryInterface $form_factory, $data = null)
     {
-        if (! is_string($this->type) || ! is_subclass_of($this->type, FormTypeInterface::class)) {
-            throw new InvalidHandlerTypeException(
-                sprintf(
-                    'Handler type expected FormTypeInterface got %s isn\'t valid.',
-                    $this->type
-                )
-            );
-        }
-
         $options = is_callable($this->options) ? call_user_func($this->options, $data) : $this->options;
 
         if (null !== $this->name) {

--- a/test/FormHandler/Fixtures/TestType.php
+++ b/test/FormHandler/Fixtures/TestType.php
@@ -19,13 +19,4 @@ class TestType extends AbstractType
             'data_class' => TestData::class
         ]);
     }
-
-    /**
-     * Backward compatibility for Symfony FormTypeInterface
-     * @deprecated
-     */
-    public function getName()
-    {
-        return '';
-    }
 }

--- a/test/FormHandler/HandlerBuilderTest.php
+++ b/test/FormHandler/HandlerBuilderTest.php
@@ -9,7 +9,6 @@ use Prophecy\Argument;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -207,35 +206,6 @@ class HandlerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder->registerActionSubscriber(new HenkSubscriber());
     }
 
-    /**
-     * @dataProvider providerBuildInvalidHandlerType
-     * @expectedException \Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException
-     */
-    public function testBuildInvalidHandlerType($type)
-    {
-        $request      = Request::create('/', 'POST');
-        $form_factory = $this->prophesize(FormFactoryInterface::class);
-
-        $form = $this->prophesize(FormInterface::class);
-        $form->handleRequest($request)->shouldNotBeCalled();
-
-        $form_factory->create(TestType::class, null, [])->willReturn($form);
-
-        $builder = new HandlerBuilder();
-        $builder->setType($type);
-
-        $handler = $builder->build($form_factory->reveal());
-        $handler->process($request);
-    }
-
-    public function providerBuildInvalidHandlerType()
-    {
-        return [
-            [600],
-            [\Exception::class]
-        ];
-    }
-    
     public function testBuildWithCustomFormSubmitProcessor()
     {
         $success = false;


### PR DESCRIPTION
Reverts #19 because symfony allows normal strings as aliases because of older versions.

This reverts commit 6e3b0a6a0a66bb1c5c0fef28b2234d6b00b601cb.

See: https://travis-ci.org/hostnet/form-handler-bundle/jobs/243549806