### PR TITLE
Don't expose request stacktrace in call_user_func

### DIFF
--- a/src/FormHandler/FormSubmitProcessor.php
+++ b/src/FormHandler/FormSubmitProcessor.php
@@ -67,7 +67,8 @@ final class FormSubmitProcessor
     public function process(Request $request)
     {
         if (is_callable($this->form_submit_processor)) {
-            call_user_func($this->form_submit_processor, $this->form, $request);
+            $form_submit_processor = $this->form_submit_processor;
+            $form_submit_processor($this->form, $request);
         } else {
             $this->form->handleRequest($request);
         }
@@ -78,10 +79,12 @@ final class FormSubmitProcessor
 
         if ($this->form->isValid()) {
             if (is_callable($this->on_success)) {
-                return call_user_func($this->on_success, $this->form->getData(), $this->form, $request);
+                $on_success = $this->on_success;
+                return $on_success($this->form->getData(), $this->form, $request);
             }
         } elseif (is_callable($this->on_failure)) {
-            return call_user_func($this->on_failure, $this->form->getData(), $this->form, $request);
+            $on_failure = $this->on_failure;
+            return $on_failure($this->form->getData(), $this->form, $request);
         }
     }
 }


### PR DESCRIPTION
When call_user_func runs a callable that throws an exception, the
exception stacktrace will contain the request object. When a logger
parses the array of functions, it might cause this processor/formatter
to call the `__toString()` function on the Request object, which will
then contain all request information, which includes passwords when
sent as post body.

See: Seldaek/monolog#1138