### PR TITLE
Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     ],
     "require": {
         "php":                     "^7.2",
-        "symfony/form":            "^4.0",
-        "symfony/http-foundation": "^4.0"
+        "symfony/form":            "^4.0||^5.0",
+        "symfony/http-foundation": "^4.0||^5.0"
     },
     "require-dev": {
         "hostnet/phpcs-tool":     "^8.3.11",
         "phpunit/phpunit":        "^8.0",
-        "symfony/debug":          "^4.0",
-        "symfony/phpunit-bridge": "^4.0"
+        "symfony/debug":          "^4.0||^5.0",
+        "symfony/phpunit-bridge": "^4.0||^5.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/test/Form/Simple/SimpleFormProviderTest.php
+++ b/test/Form/Simple/SimpleFormProviderTest.php
@@ -10,6 +10,7 @@ use Hostnet\Component\Form\Exception\FormNotFoundException;
 use Hostnet\Component\Form\FormHandlerInterface;
 use Hostnet\Component\Form\NamedFormHandlerInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -125,6 +126,11 @@ class SimpleFormProviderTest extends TestCase
             ->method('setForm')
             ->with($this->form);
 
+        $this->handler
+            ->expects(self::once())
+            ->method('getType')
+            ->willReturn(FormType::class);
+
         $provider = new SimpleFormProvider($this->factory);
         $provider->handle(new Request(), $this->handler);
     }
@@ -151,6 +157,11 @@ class SimpleFormProviderTest extends TestCase
             ->expects(self::once())
             ->method('setForm')
             ->with($this->form);
+
+        $named_handler
+            ->expects(self::once())
+            ->method('getType')
+            ->willReturn(FormType::class);
 
         $provider = new SimpleFormProvider($this->factory);
         $provider->handle(new Request(), $named_handler);
@@ -179,6 +190,11 @@ class SimpleFormProviderTest extends TestCase
             ->method('setForm')
             ->with($this->form);
 
+        $named_handler
+            ->expects(self::once())
+            ->method('getType')
+            ->willReturn(FormType::class);
+
         $provider = new SimpleFormProvider($this->factory);
         $provider->handle(new Request(), $named_handler);
     }
@@ -189,6 +205,11 @@ class SimpleFormProviderTest extends TestCase
             ->expects(self::once())
             ->method('getOptions')
             ->willReturn([]);
+
+        $this->handler
+            ->expects(self::any())
+            ->method('getType')
+            ->willReturn(FormType::class);
 
         $provider = new SimpleFormProvider($this->factory);
 

--- a/test/FormHandler/HandlerTypeAdapterTest.php
+++ b/test/FormHandler/HandlerTypeAdapterTest.php
@@ -12,7 +12,6 @@ use Hostnet\Component\FormHandler\Fixtures\TestData;
 use Hostnet\Component\FormHandler\Fixtures\TestType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**


### PR DESCRIPTION
I had a bit of time, and November is fast approaching. :tada: 

- Updated Symfony constraints to include `^5.0`
- ~Updated PHPUnit constraint to include `^7.5`~
- Updated PHPUnit TestCase namespaces to match

Notes:
- `symfony/debug` is being removed/replaced in Symfony 5, but forward compat. comes in 4.4


For local testing:
```json
       "symfony/form":            "dev-master@dev",
       "symfony/http-foundation": "dev-master@dev"
       "symfony/debug":          "4.4.x-dev@dev",
       "symfony/phpunit-bridge": "dev-master@dev"
```

Let me know if you want anything more.