### PR TITLE
Allow Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,15 @@
     "minimum-stability": "stable",
     "require": {
         "php":                     "^7.3||^8.0",
-        "symfony/form":            "^4.0||^5.0",
-        "symfony/http-foundation": "^4.0||^5.0"
+        "symfony/form":            "^4.0||^5.0||^6.0",
+        "symfony/http-foundation": "^4.0||^5.0||^6.0"
     },
     "require-dev": {
         "hostnet/phpcs-tool":       "^9.1.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit":          "^9.5.5",
-        "symfony/debug":            "^4.0||^5.0",
-        "symfony/phpunit-bridge":   "^4.0||^5.0"
+        "symfony/debug":            "^4.0",
+        "symfony/phpunit-bridge":   "^4.0||^5.0||^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Simple `composer.json` edit that allows Symfony 6, which seems to just work.

---

I removed `^5.0` from `symfony/debug` as it never existed (and in fact has been replaced by `symfony/error-handler`).